### PR TITLE
add CORS headers to responses

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -45,9 +45,14 @@ app = VersionedFastAPI(
     enable_latest=True,
 )
 
+origins = [
+    "http://localhost",
+    "http://localhost:3000",
+]
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/app/main.py
+++ b/app/main.py
@@ -20,6 +20,7 @@ from app.repositories.lightning import register_lightning_listener
 from app.repositories.system import register_hardware_info_gatherer
 from app.routers import apps, bitcoin, lightning, setup, system
 from app.sse_starlette import EventSourceResponse
+from starlette.middleware.cors import CORSMiddleware
 
 
 @registered_configuration
@@ -42,6 +43,14 @@ app = VersionedFastAPI(
     version_format="{major}",
     prefix_format="/v{major}",
     enable_latest=True,
+)
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
 )
 
 


### PR DESCRIPTION
This adds CORS headers to the responses so raspiblitz-web can subscribe to the SSE endpoint in local development