### PR TITLE
#94 pubkey info on lightning lite info

### DIFF
--- a/app/models/lightning.py
+++ b/app/models/lightning.py
@@ -1351,6 +1351,7 @@ class LightningInfoLite(BaseModel):
         ..., description="Lightning software implementation (LND, c-lightning)"
     )
     version: str = Query(..., description="Version of the implementation")
+    identity_pubkey: str = Query(..., description="The identity pubkey of the current node")
     num_pending_channels: int = Query(..., description="Number of pending channels")
     num_active_channels: int = Query(..., description="Number of active channels")
     num_inactive_channels: int = Query(..., description="Number of inactive channels")
@@ -1371,6 +1372,7 @@ class LightningInfoLite(BaseModel):
         return cls(
             implementation=info.implementation,
             version=info.version,
+            identity_pubkey=info.identity_pubkey,
             num_pending_channels=info.num_pending_channels,
             num_active_channels=info.num_active_channels,
             num_inactive_channels=info.num_inactive_channels,

--- a/app/repositories/lightning.py
+++ b/app/repositories/lightning.py
@@ -29,6 +29,8 @@ elif lightning_config.ln_node == "cln_grpc":
     import app.repositories.ln_impl.cln_grpc as ln
 elif lightning_config.ln_node == "cln_unix_socket":
     import app.repositories.ln_impl.cln_unix_socket as ln
+else:
+    logging.error(f"lightning_config.ln_node unkown ({lightning_config.ln_node})")
 
 GATHER_INFO_INTERVALL = config("gather_ln_info_interval", default=2, cast=float)
 


### PR DESCRIPTION
Fixes #94 Worked for `lnd` but was not able to test with `cl` because I get on error before I can can parse the info further.

```
Jun 06 21:39:18 python[110174]:   File "./app/repositories/ln_impl/cln_grpc.py", line 477, in get_ln_info_impl
Jun 06 21:39:18 python[110174]:     res = await lncfg.cln_stub.Getinfo(req)
Jun 06 21:39:18 python[110174]:   File "/usr/local/lib/python3.9/dist-packages/grpc/aio/_call.py", line 290, in __await__
Jun 06 21:39:18 python[110174]:     raise _create_rpc_error(self._cython_call._initial_metadata,
Jun 06 21:39:18 python[110174]: grpc.aio._call.AioRpcError: <AioRpcError of RPC that terminated with:
Jun 06 21:39:18 python[110174]:         status = StatusCode.UNAVAILABLE
Jun 06 21:39:18 python[110174]:         details = "failed to connect to all addresses"
Jun 06 21:39:18 python[110174]:         debug_error_string = "{"created":"@1654547958.117541682","description":"Failed to pick subchannel","file":"src/core/ext/filters/client_channel/client_channel.cc","file_line":3093,"referenced_errors":[{"created":"@1654547958.117538015","description":"failed to connect to all addresses","file":"src/core/lib/transport/error_utils.cc","file_line":163,"grpc_status":14}]}"
Jun 06 21:39:18 python[110174]: >
Jun 06 21:39:18 python[110174]: ERROR:    Application startup failed. Exiting.
```