### PR TITLE
fix: install for python 3.9 and add hash

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -659,7 +659,8 @@ starlette==0.19.1; python_version >= "3.6" and python_full_version >= "3.6.1" \
 tenacity==8.0.1; python_version >= "3.6" and python_full_version >= "3.6.0" \
     --hash=sha256:f78f4ea81b0fabc06728c11dc2a8c01277bfc5181b321a4770471902e3eb844a \
     --hash=sha256:43242a20e3e73291a28bcbcacfd6e000b02d3857a9a9fff56b297a27afdc932f
-typing-extensions==4.2.0; python_version >= "3.7" and python_full_version >= "3.6.2" and python_version < "3.8" \
+typing-extensions==4.2.0; python_version >= "3.7" and python_full_version >= "3.6.2" \
+    --hash=sha256:fa30ff068156fd1b6419c12317916cc35b23e3115fabddf46de0dd72abeb2a4a \
     --hash=sha256:6657594ee297170d19f67d55c05852a874e7eb634f4f753dbd667855e07c1708 \
     --hash=sha256:f1c24655a0da0d1b67f07e17a5e6b2a105894e6824b92096378bb3668ef02376
 urllib3==1.26.9; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version < "4" \


### PR DESCRIPTION
discussed in https://github.com/rootzoll/raspiblitz/issues/3170#issuecomment-1159568376