### PR TITLE
fix: password regex

### DIFF
--- a/app/repositories/system.py
+++ b/app/repositories/system.py
@@ -58,7 +58,7 @@ def password_valid(password: str):
         return False
     if password.find(" ") >= 0:
         return False
-    return re.match("^[a-zA-Z0-9]*$", password)
+    return re.match("^[a-zA-Z0-9\-\.]*$", password)
 
 
 def name_valid(password: str):


### PR DESCRIPTION
Adapts the password regex to be the same as the Raspiblitz does. See https://github.com/rootzoll/raspiblitz/issues/3260.