### PR TITLE
Stop log spam for missing tor_web_addr

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -58,7 +58,11 @@ async def redis_get(key: str) -> str:
     v = await redis_plugin.redis.get(key)
 
     if not v:
-        logging.info(f"Key '{key}' not found in Redis DB.")
+        logstr = f"Key '{key}' not found in Redis DB."
+        if "tor_web_addr" in key:
+            logging.info(logstr)
+        else:
+            logging.warning(logstr)
         return ""
 
     return v.decode("utf-8")

--- a/app/utils.py
+++ b/app/utils.py
@@ -58,8 +58,7 @@ async def redis_get(key: str) -> str:
     v = await redis_plugin.redis.get(key)
 
     if not v:
-        if not "tor_web_addr" in key:
-            logging.warning(f"Key '{key}' not found in Redis DB.")
+        logging.info(f"Key '{key}' not found in Redis DB.")
         return ""
 
     return v.decode("utf-8")

--- a/app/utils.py
+++ b/app/utils.py
@@ -58,7 +58,8 @@ async def redis_get(key: str) -> str:
     v = await redis_plugin.redis.get(key)
 
     if not v:
-        logging.warning(f"Key '{key}' not found in Redis DB.")
+        if not "tor_web_addr" in key:
+            logging.warning(f"Key '{key}' not found in Redis DB.")
         return ""
 
     return v.decode("utf-8")


### PR DESCRIPTION
In case tor is not used, we can not find a tor_web_addr key in redis db. This will prevent from spamming the journal.