### PR TITLE
has no attribute 'decode' fix for redis db

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -65,7 +65,10 @@ async def redis_get(key: str) -> str:
             logging.warning(logstr)
         return ""
 
-    return v.decode("utf-8")
+    try:
+        return v.decode("utf-8")
+    except:
+        return v
 
 
 # TODO


### PR DESCRIPTION
This will only try to decode if it is needed