### PR TITLE
feat(#237): implement app_status_advanced endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,3 @@ pyrightconfig.json
 
 # Nix
 result
-

--- a/app/apps/impl/apps_base.py
+++ b/app/apps/impl/apps_base.py
@@ -11,6 +11,10 @@ class AppsBase:
         raise NotImplementedError()
 
     @abstractmethod
+    async def get_app_status_advanced(self, app_id: str):
+        raise NotImplementedError()
+
+    @abstractmethod
     async def get_app_status_sub(self):
         raise NotImplementedError()
 

--- a/app/apps/impl/native_python.py
+++ b/app/apps/impl/native_python.py
@@ -18,6 +18,9 @@ class NativePythonApps(AppsBase):
     async def get_app_status(self):
         raise _NotImplemented()
 
+    async def get_app_status_advanced(self, app_id: str):
+        raise _NotImplemented()
+
     async def get_app_status_sub(self):
         raise _NotImplemented()
 

--- a/app/apps/impl/raspiblitz.py
+++ b/app/apps/impl/raspiblitz.py
@@ -395,4 +395,4 @@ async def _do_electrs_status_advanced():
             "error": f"script not working for api: {script_call}",
         }
 
-    return {"initialSyncDone": data["initialSynced"] == 1}
+    return {"initialSyncDone": data["initialSynced"] == '1'}

--- a/app/apps/impl/raspiblitz.py
+++ b/app/apps/impl/raspiblitz.py
@@ -129,13 +129,15 @@ class RaspiBlitzApps(AppsBase):
 
     async def get_app_status_advanced(self, app_id):
         if app_id not in available_app_ids:
-            return {
-                "id": f"{app_id}",
-                "error": "appID not in list",
-            }
+            raise HTTPException(
+                status.HTTP_400_BAD_REQUEST,
+                detail=f"App id invalid. Available app ids: {available_app_ids}",
+            )
 
         if app_id == "electrs":
-            return _do_electrs_status_advanced()
+            return await _do_electrs_status_advanced()
+
+        return {}
 
     async def get_app_status(self):
         appStatusList: List = []
@@ -393,4 +395,4 @@ async def _do_electrs_status_advanced():
             "error": f"script not working for api: {script_call}",
         }
 
-    return {"initialSynced": data["initialSynced"]}
+    return {"initialSyncDone": data["initialSynced"] == 1}

--- a/app/apps/impl/raspiblitz.py
+++ b/app/apps/impl/raspiblitz.py
@@ -366,7 +366,7 @@ async def _do_electrs_status_advanced():
     app_id = "electrs"
     script_call = (
         os.path.join(SHELL_SCRIPT_PATH, "config.scripts", f"bonus.{app_id}.sh")
-        + " status"
+        + " status showAddress"
     )
 
     try:
@@ -388,6 +388,18 @@ async def _do_electrs_status_advanced():
             "error": f"script result parsing error: {script_call}",
         }
 
+    if data["serviceInstalled"] == "0":
+        return {
+            "id": app_id,
+            "error": "Service not installed.",
+        }
+
+    if data["serviceRunning"] == "0":
+        return {
+            "id": app_id,
+            "error": "Service installed, but not running.",
+        }
+
     if "initialSynced" not in data:
         logging.warning(f"error on calling: {script_call}")
         return {
@@ -395,4 +407,12 @@ async def _do_electrs_status_advanced():
             "error": f"script not working for api: {script_call}",
         }
 
-    return {"initialSyncDone": data["initialSynced"] == "1"}
+    return {
+        "version": data["version"],
+        "localIP": data["localIP"],
+        "publicIP": data["publicIP"],
+        "portTCP": data["portTCP"],
+        "portSSL": data["portSSL"],
+        "TORaddress": data["TORaddress"],
+        "initialSyncDone": data["initialSynced"] == "1",
+    }

--- a/app/apps/impl/raspiblitz.py
+++ b/app/apps/impl/raspiblitz.py
@@ -395,4 +395,4 @@ async def _do_electrs_status_advanced():
             "error": f"script not working for api: {script_call}",
         }
 
-    return {"initialSyncDone": data["initialSynced"] == '1'}
+    return {"initialSyncDone": data["initialSynced"] == "1"}

--- a/app/apps/router.py
+++ b/app/apps/router.py
@@ -37,6 +37,20 @@ async def get_single_status(id):
 
 
 @router.get(
+    "/status_advanced/{id}",
+    name=f"{_PREFIX}/status_advanced",
+    summary="""Get the advanced status of a single app by id.
+Some apps might give status information that is computationally to
+expensive to include in the normal status endpoint.
+    """,
+    dependencies=[Depends(JWTBearer())],
+)
+@logger.catch(exclude=(HTTPException,))
+async def get_single_status_advanced(id):
+    return await repo.get_app_status_single_advanced(id)
+
+
+@router.get(
     "/status-sub",
     name=f"{_PREFIX}/status-sub",
     summary="Subscribe to status changes of currently installed apps.",

--- a/app/apps/router.py
+++ b/app/apps/router.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Path
 from fastapi.params import Depends
 from loguru import logger
 from pydantic import BaseModel
@@ -39,15 +39,18 @@ async def get_single_status(id):
 @router.get(
     "/status_advanced/{id}",
     name=f"{_PREFIX}/status_advanced",
-    summary="""Get the advanced status of a single app by id.
-Some apps might give status information that is computationally to
-expensive to include in the normal status endpoint.
+    summary="Get the advanced status of a single app by id.",
+    description="""Some apps might give status information that is computationally
+    to expensive to include in the normal status endpoint.
+
+> ℹ️ _This endpoint is not implemented on all platforms_
     """,
     dependencies=[Depends(JWTBearer())],
+    responses={400: {"description": ("If no or invalid app id is given.")}},
 )
 @logger.catch(exclude=(HTTPException,))
-async def get_single_status_advanced(id):
-    return await repo.get_app_status_single_advanced(id)
+async def get_single_status_advanced(id: str = Path(..., required=True)):
+    return await repo.get_app_status_advanced(id)
 
 
 @router.get(

--- a/app/apps/service.py
+++ b/app/apps/service.py
@@ -25,7 +25,7 @@ async def get_app_status():
 
 
 async def get_app_status_advanced(app_id: str):
-    return await apps.get_app_status_single_advanced(app_id)
+    return await apps.get_app_status_advanced(app_id)
 
 
 async def get_app_status_sub():

--- a/app/apps/service.py
+++ b/app/apps/service.py
@@ -24,6 +24,10 @@ async def get_app_status():
     return await apps.get_app_status()
 
 
+async def get_app_status_advanced(app_id: str):
+    return await apps.get_app_status_single_advanced(app_id)
+
+
 async def get_app_status_sub():
     return await apps.get_app_status_sub()
 


### PR DESCRIPTION
Some apps might give status information that is computationally to expensive to include in the normal status endpoint which can be polled more often.