### PR TITLE
Fix/use hashed password login

### DIFF
--- a/app/system/impl/native_python.py
+++ b/app/system/impl/native_python.py
@@ -1,5 +1,6 @@
 import logging
 import secrets
+import bcrypt
 from typing import Dict
 
 import psutil
@@ -22,7 +23,6 @@ from app.system.models import (
 _SLEEP_TIME = config("gather_hw_info_interval", default=2, cast=float)
 _CPU_AVG_PERIOD = config("cpu_usage_averaging_period", default=0.5, cast=float)
 _HW_INFO_YIELD_TIME = _SLEEP_TIME + _CPU_AVG_PERIOD
-
 
 class NativePythonSystem(SystemBase):
     async def get_system_info(self) -> SystemInfo:
@@ -64,8 +64,8 @@ class NativePythonSystem(SystemBase):
         return ConnectionInfo()
 
     async def login(self, i: LoginInput) -> Dict[str, str]:
-        matches = secrets.compare_digest(i.password, config("login_password", cast=str))
-        if matches:
+        hashed_password = config("login_hashed_password", cast=str)
+        if bcrypt.checkpw(i.password.encode('utf-8'), hashed_password.encode('utf-8')):
             return sign_jwt()
 
         raise HTTPException(

--- a/app/system/impl/native_python.py
+++ b/app/system/impl/native_python.py
@@ -1,8 +1,8 @@
 import logging
 import secrets
-import bcrypt
 from typing import Dict
 
+import bcrypt
 import psutil
 from decouple import config
 from fastapi import HTTPException, status
@@ -23,6 +23,7 @@ from app.system.models import (
 _SLEEP_TIME = config("gather_hw_info_interval", default=2, cast=float)
 _CPU_AVG_PERIOD = config("cpu_usage_averaging_period", default=0.5, cast=float)
 _HW_INFO_YIELD_TIME = _SLEEP_TIME + _CPU_AVG_PERIOD
+
 
 class NativePythonSystem(SystemBase):
     async def get_system_info(self) -> SystemInfo:
@@ -65,7 +66,7 @@ class NativePythonSystem(SystemBase):
 
     async def login(self, i: LoginInput) -> Dict[str, str]:
         hashed_password = config("login_password", cast=str)
-        if bcrypt.checkpw(i.password.encode('utf-8'), hashed_password.encode('utf-8')):
+        if bcrypt.checkpw(i.password.encode("utf-8"), hashed_password.encode("utf-8")):
             return sign_jwt()
 
         raise HTTPException(

--- a/app/system/impl/native_python.py
+++ b/app/system/impl/native_python.py
@@ -1,5 +1,4 @@
 import logging
-import secrets
 from typing import Dict
 
 import bcrypt

--- a/app/system/impl/native_python.py
+++ b/app/system/impl/native_python.py
@@ -64,7 +64,7 @@ class NativePythonSystem(SystemBase):
         return ConnectionInfo()
 
     async def login(self, i: LoginInput) -> Dict[str, str]:
-        hashed_password = config("login_hashed_password", cast=str)
+        hashed_password = config("login_password", cast=str)
         if bcrypt.checkpw(i.password.encode('utf-8'), hashed_password.encode('utf-8')):
             return sign_jwt()
 

--- a/app/system/router.py
+++ b/app/system/router.py
@@ -170,7 +170,9 @@ async def hw_info_sub(request: Request):
 async def get_system_health(
     verbose: bool = Query(
         False,
-        description="Returns info about each subsytem running on this node if true. Currently not implemented.",
+        description="""Returns info about each 
+        subsytem running on this node if
+        true. Currently not implemented.""",
     ),
 ) -> SystemHealthInfo:
     return await system_health(verbose)

--- a/app/system/router.py
+++ b/app/system/router.py
@@ -170,7 +170,7 @@ async def hw_info_sub(request: Request):
 async def get_system_health(
     verbose: bool = Query(
         False,
-        description="""Returns info about each 
+        description="""Returns info about each
         subsytem running on this node if
         true. Currently not implemented.""",
     ),

--- a/tests/repositories/test_system.py
+++ b/tests/repositories/test_system.py
@@ -16,7 +16,7 @@ async def test_login(monkeypatch):
     )
 
     res = await sys.login(i=LoginInput(password="12345678"))
-    assert type(res) is dict
+    assert isinstance(res, dict)
     assert res.startswith("ey") is True
 
     async def fake_match_pw_negative(_):


### PR DESCRIPTION
- Replaced clear text password comparison with hashed password comparison using bcrypt.
- Enhanced security by avoiding the storage and comparison of plain text passwords.

Fixes issue [#255.](https://github.com/fusion44/blitz_api/issues/255)