### PR TITLE
fix: send installed_app_status correctly for bitcoin only nodes

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -328,7 +328,8 @@ async def warmup_new_connections():
                     *[
                         _handle(id, SSE.SYSTEM_INFO, res[0]),
                         _handle(id, SSE.BTC_INFO, res[1]),
-                        _handle(id, SSE.HARDWARE_INFO, res[2]),
+                        _handle(id, SSE.INSTALLED_APP_STATUS, res[2]),
+                        _handle(id, SSE.HARDWARE_INFO, res[3]),
                     ]
                 )
 


### PR DESCRIPTION
https://github.com/fusion44/blitz_api/blob/dev/app/api/warmup.py#L76 already sends the message, but it was sent as `hardware_info`.

Should at least fix https://github.com/raspiblitz/raspiblitz/issues/4743
Maybe https://github.com/raspiblitz/raspiblitz/issues/4631 & the others.
